### PR TITLE
Allow dhcp_subnet range attribute to accept String

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,27 +1,17 @@
 AllCops:
-  Include:
-    - metadata.rb
-    - Gemfile
-    - attributes/**/*
-    - recipes/**/*
-    - libraries/**/*
-    - providers/**/*
-    - resources/**/*
-      
   Exclude:
+    - Rakefile
     - bin/**/*
     - test/**/*
     - vendor/**/*
-
-Encoding:
-  Exclude:
-    - metadata.rb
-    - Gemfile
 
 LineLength:
   Enabled: false
 
 Style/Next:
+  Enabled: false
+
+Style/Encoding:
   Enabled: false
 
 WordArray:

--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -1,0 +1,11 @@
+if defined?(ChefSpec)
+  ChefSpec.define_matcher :dhcp_subnet
+
+  def add_dhcp_subnet(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:dhcp_subnet, :add, resource_name)
+  end
+
+  def remove_dhcp_subnet(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:dhcp_subnet, :remove, resource_name)
+  end
+end

--- a/providers/subnet.rb
+++ b/providers/subnet.rb
@@ -24,9 +24,10 @@ def write_include
 end
 
 action :add do
-
   directory "#{new_resource.conf_dir}/subnets.d/"
 
+  range = new_resource.range
+  range = [new_resource.range] if new_resource.range.is_a? String
   t = template "#{new_resource.conf_dir}/subnets.d/#{new_resource.name}.conf" do
     cookbook 'dhcp'
     source 'subnet.conf.erb'
@@ -36,7 +37,7 @@ action :add do
       broadcast: new_resource.broadcast,
       routers: new_resource.routers,
       options: new_resource.options,
-      range: new_resource.range,
+      range: range,
       peer: new_resource.peer,
       evals: new_resource.evals,
       key: new_resource.key,

--- a/recipes/_networks.rb
+++ b/recipes/_networks.rb
@@ -2,6 +2,9 @@
 #
 # Setup subnets
 #
+
+include_recipe 'dhcp::_service'
+
 if node[:dhcp][:networks].empty?
   Chef::Log.info('Attribute node[:dhcp][:networks] is empty, guess you are using LWRP')
   return

--- a/resources/subnet.rb
+++ b/resources/subnet.rb
@@ -8,7 +8,7 @@ attribute :broadcast, kind_of: String
 attribute :netmask, kind_of: String
 attribute :routers, kind_of: Array, default: []
 attribute :options, kind_of: Array, default: []
-attribute :range, kind_of: Array
+attribute :range, kind_of: [Array, String]
 attribute :ddns, kind_of: String, default: nil
 attribute :peer, kind_of: String, default: nil
 attribute :evals, kind_of: Array, default: []

--- a/test/spec/_networks_spec.rb
+++ b/test/spec/_networks_spec.rb
@@ -3,14 +3,45 @@ require_relative 'helpers/data'
 
 describe "dhcp::_networks Exceptions" do
   before(:each) do
-    Fauxhai.mock(platform:'ubuntu', version:'12.04')
+    Fauxhai.mock(platform: 'ubuntu', version: '12.04')
     @chef_run = ChefSpec::Runner.new
   end
-
 
   it 'should not raise error unless when bags are missing' do
     @chef_run.converge "dhcp::_networks"
   end
 end
 
+describe 'dhcp::_networks' do
+  context 'driven by node attributes' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new(platform: 'centos', version: '6.6', step_into: ['dhcp_subnet']) do |node|
+        node.set[:chef_environment] = 'production'
+        node.set[:dhcp][:use_bags] = false
+        node.set[:dhcp][:networks] = ['192.168.9.0/24']
+        node.set[:dhcp][:network_data]['192.168.9.0/24'] = {
+          'id' => '192-168-9-0_24',
+          'routers'   => ['192.168.9.1'],
+          'address'   => '192.168.9.0',
+          'netmask'   => '255.255.255.0',
+          'broadcast' => '192.168.9.255',
+          'range'     => '192.168.9.50 192.168.9.240',
+          'options'   => ['next-server 192.168.9.11']
+        }
+      end.converge(described_recipe)
+    end
 
+    it 'declares subnet 192.168.9.0' do
+      expect(chef_run).to add_dhcp_subnet('192.168.9.0')
+        .with(broadcast: '192.168.9.255', netmask: '255.255.255.0', routers: ['192.168.9.1'],
+              options: ['next-server 192.168.9.11'],
+              range: '192.168.9.50 192.168.9.240', conf_dir: '/etc/dhcp',
+              evals: [], key: {}, zones: [])
+    end
+
+    it 'generates subnet config for 192.168.9.0' do
+      expect(chef_run).to create_template '/etc/dhcp/subnets.d/192.168.9.0.conf'
+      expect(chef_run).to render_file('/etc/dhcp/subnets.d/192.168.9.0.conf').with_content(File.read File.join(File.dirname(__FILE__), 'fixtures', '192.168.9.0.conf'))
+    end
+  end
+end

--- a/test/spec/fixtures/192.168.9.0.conf
+++ b/test/spec/fixtures/192.168.9.0.conf
@@ -1,0 +1,14 @@
+# File managed by Chef
+
+subnet 192.168.9.0 netmask 255.255.255.0 {
+pool {
+  range 192.168.9.50 192.168.9.240;
+}
+  option routers 192.168.9.1;
+  option subnet-mask 255.255.255.0;
+  option broadcast-address 192.168.9.255;
+  option next-server 192.168.9.11;
+
+
+
+}


### PR DESCRIPTION
If a String is passed to dhcp_subnet range then the provider will convert the String to a single element array.

This fixes #45 