### PR TITLE
Include subconfig files in list.conf properly on Chef 12

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 module Dhcp
   #
   # Helper methods that are used in multiple providers

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -1,0 +1,55 @@
+module Dhcp
+  #
+  # Helper methods that are used in multiple providers
+  #
+  module Helpers
+    #
+    # Determine if the resource matches this resource's type
+    #
+    # @param resource the resource to check
+    #
+    # @return [TrueClass, FalseClass] wether or not the resource matches
+    #
+    def resource_match?(resource)
+      # Check for >= Chef 12
+      return true if Gem::Version.new(Chef::VERSION) >= Gem::Version.new('12.0.0') && resource.declared_type == new_resource.declared_type
+
+      # Check for <= Chef 11
+      return true if Gem::Version.new(Chef::VERSION) < Gem::Version.new('12.0.0') && resource.resource_name == new_resource.resource_name
+
+      false
+    end
+
+    #
+    # List of files to include in list.conf for a collection of subconfigs (e.g. hosts, subnets, groups)
+    #
+    # @param [String] sub_dir - The subconfig directory for the config
+    #
+    # @return [Array<String>] An array of config files for the subconfig
+    def includes(sub_dir)
+      run_context.resource_collection.map do |resource|
+        next unless resource_match? resource
+        next unless resource.action == :add || resource.action.include?(:add)
+        "#{resource.conf_dir}/#{sub_dir}/#{resource.name}.conf"
+      end.compact
+    end
+
+    #
+    # Defined resource for list.conf to include all subconfig files
+    #
+    # @param [String] sub_dir - The subconfig directory for the config
+    #
+    def write_include(sub_dir)
+      t = template "#{new_resource.conf_dir}/#{sub_dir}/list.conf" do
+        cookbook 'dhcp'
+        source 'list.conf.erb'
+        owner 'root'
+        group 'root'
+        mode 0644
+        variables(files: includes(sub_dir))
+        notifies :restart, "service[#{node[:dhcp][:service_name]}]", :delayed
+      end
+      new_resource.updated_by_last_action(t.updated?)
+    end
+  end
+end

--- a/providers/group.rb
+++ b/providers/group.rb
@@ -1,26 +1,6 @@
 # encoding: UTF-8
 
-def includes
-  run_context.resource_collection.map do |resource|
-    next if Gem::Version.new(Chef::VERSION) >= Gem::Version.new('12.0.0') && resource.declared_type != new_resource.declared_type
-    next if Gem::Version.new(Chef::VERSION) < Gem::Version.new('12.0.0') && resource.resource_name != new_resource.resource_name
-    next unless resource.action == :add || resource.action.include?(:add)
-    "#{resource.conf_dir}/groups.d/#{resource.name}.conf"
-  end.compact
-end
-
-def write_include
-  t = template "#{new_resource.conf_dir}/groups.d/list.conf" do
-    cookbook 'dhcp'
-    source 'list.conf.erb'
-    owner 'root'
-    group 'root'
-    mode 0644
-    variables(files: includes)
-    notifies :restart, "service[#{node[:dhcp][:service_name]}]", :delayed
-  end
-  new_resource.updated_by_last_action(t.updated?)
-end
+include Dhcp::Helpers
 
 action :add do
   directory "#{new_resource.conf_dir}/groups.d"
@@ -41,7 +21,7 @@ action :add do
   end
   new_resource.updated_by_last_action(t.updated?)
 
-  write_include
+  write_include 'groups.d'
 end
 
 action :remove do
@@ -52,5 +32,5 @@ action :remove do
   end
   new_resource.updated_by_last_action(f.updated?)
 
-  write_include
+  write_include 'groups.d'
 end

--- a/providers/group.rb
+++ b/providers/group.rb
@@ -1,13 +1,12 @@
 # encoding: UTF-8
 
 def includes
-  file_includes = []
-  run_context.resource_collection.each do |resource|
-    if resource.is_a?(Chef::Resource::DhcpGroup) && resource.action == :add
-      file_includes << "#{resource.conf_dir}/groups.d/#{resource.name}.conf"
-    end
-  end
-  file_includes
+  run_context.resource_collection.map do |resource|
+    next if Gem::Version.new(Chef::VERSION) >= Gem::Version.new('12.0.0') && resource.declared_type != new_resource.declared_type
+    next if Gem::Version.new(Chef::VERSION) < Gem::Version.new('12.0.0') && resource.resource_name != new_resource.resource_name
+    next unless resource.action == :add || resource.action.include?(:add)
+    "#{resource.conf_dir}/groups.d/#{resource.name}.conf"
+  end.compact
 end
 
 def write_include

--- a/providers/host.rb
+++ b/providers/host.rb
@@ -33,5 +33,5 @@ action :remove do
   end
   new_resource.updated_by_last_action(f.updated?)
 
-  write_include 'groups.d'
+  write_include 'hosts.d'
 end

--- a/providers/host.rb
+++ b/providers/host.rb
@@ -1,27 +1,7 @@
 # encoding: UTF-8
 #
-# TODO: these should be put into a lib/mixin since we use it everywhere
-def includes
-  run_context.resource_collection.map do |resource|
-    next if Gem::Version.new(Chef::VERSION) >= Gem::Version.new('12.0.0') && resource.declared_type != new_resource.declared_type
-    next if Gem::Version.new(Chef::VERSION) < Gem::Version.new('12.0.0') && resource.resource_name != new_resource.resource_name
-    next unless resource.action == :add || resource.action.include?(:add)
-    "#{resource.conf_dir}/hosts.d/#{resource.hostname}.conf"
-  end.compact
-end
 
-def write_include
-  t = template "#{new_resource.conf_dir}/hosts.d/list.conf" do
-    cookbook 'dhcp'
-    source 'list.conf.erb'
-    owner 'root'
-    group 'root'
-    mode 0644
-    variables(files: includes)
-    notifies :restart, "service[#{node[:dhcp][:service_name]}]", :delayed
-  end
-  new_resource.updated_by_last_action(t.updated?)
-end
+include Dhcp::Helpers
 
 action :add do
   directory "#{new_resource.conf_dir}/hosts.d/"
@@ -43,7 +23,7 @@ action :add do
     notifies :restart, "service[#{node[:dhcp][:service_name]}]", :delayed
   end
   new_resource.updated_by_last_action(t.updated?)
-  write_include
+  write_include 'hosts.d'
 end
 
 action :remove do
@@ -53,5 +33,5 @@ action :remove do
   end
   new_resource.updated_by_last_action(f.updated?)
 
-  write_include
+  write_include 'groups.d'
 end

--- a/providers/host.rb
+++ b/providers/host.rb
@@ -2,13 +2,12 @@
 #
 # TODO: these should be put into a lib/mixin since we use it everywhere
 def includes
-  file_includes = []
-  run_context.resource_collection.each do |resource|
-    if resource.is_a?(Chef::Resource::DhcpHost) && resource.action == :add
-      file_includes << "#{resource.conf_dir}/hosts.d/#{resource.hostname}.conf"
-    end
-  end
-  file_includes
+  run_context.resource_collection.map do |resource|
+    next if Gem::Version.new(Chef::VERSION) >= Gem::Version.new('12.0.0') && resource.declared_type != new_resource.declared_type
+    next if Gem::Version.new(Chef::VERSION) < Gem::Version.new('12.0.0') && resource.resource_name != new_resource.resource_name
+    next unless resource.action == :add || resource.action.include?(:add)
+    "#{resource.conf_dir}/hosts.d/#{resource.hostname}.conf"
+  end.compact
 end
 
 def write_include

--- a/providers/subnet.rb
+++ b/providers/subnet.rb
@@ -1,26 +1,6 @@
 # encoding: UTF-8
 
-def includes
-  run_context.resource_collection.map do |resource|
-    next if Gem::Version.new(Chef::VERSION) >= Gem::Version.new('12.0.0') && resource.declared_type != new_resource.declared_type
-    next if Gem::Version.new(Chef::VERSION) < Gem::Version.new('12.0.0') && resource.resource_name != new_resource.resource_name
-    next unless resource.action == :add || resource.action.include?(:add)
-    "#{resource.conf_dir}/subnets.d/#{resource.name}.conf"
-  end.compact
-end
-
-def write_include
-  t = template "#{new_resource.conf_dir}/subnets.d/list.conf" do
-    cookbook 'dhcp'
-    source 'list.conf.erb'
-    owner 'root'
-    group 'root'
-    mode 0644
-    variables(files: includes)
-    notifies :restart, "service[#{node[:dhcp][:service_name]}]", :delayed
-  end
-  new_resource.updated_by_last_action(t.updated?)
-end
+include Dhcp::Helpers
 
 action :add do
 
@@ -49,7 +29,7 @@ action :add do
   end
   new_resource.updated_by_last_action(t.updated?)
 
-  write_include
+  write_include 'subnets.d'
 end
 
 action :remove do
@@ -59,5 +39,5 @@ action :remove do
     notifies :send_notification, new_resource, :immediately
   end
   new_resource.updated_by_last_action(f.updated?)
-  write_include
+  write_include 'groups.d'
 end

--- a/providers/subnet.rb
+++ b/providers/subnet.rb
@@ -1,13 +1,12 @@
 # encoding: UTF-8
 
 def includes
-  file_includes = []
-  run_context.resource_collection.each do |resource|
-    if resource.is_a?(Chef::Resource::DhcpSubnet) && resource.action == :add
-      file_includes << "#{resource.conf_dir}/subnets.d/#{resource.name}.conf"
-    end
-  end
-  file_includes
+  run_context.resource_collection.map do |resource|
+    next if Gem::Version.new(Chef::VERSION) >= Gem::Version.new('12.0.0') && resource.declared_type != new_resource.declared_type
+    next if Gem::Version.new(Chef::VERSION) < Gem::Version.new('12.0.0') && resource.resource_name != new_resource.resource_name
+    next unless resource.action == :add || resource.action.include?(:add)
+    "#{resource.conf_dir}/subnets.d/#{resource.name}.conf"
+  end.compact
 end
 
 def write_include

--- a/providers/subnet.rb
+++ b/providers/subnet.rb
@@ -39,5 +39,5 @@ action :remove do
     notifies :send_notification, new_resource, :immediately
   end
   new_resource.updated_by_last_action(f.updated?)
-  write_include 'groups.d'
+  write_include 'subnets.d'
 end


### PR DESCRIPTION
When testing with test-kitchen (assuming you have range attribute issue #45 fixed #46) the next issue you'll run into is no subconfigs being loaded.  This is due to changes in generated resources no longer having a `resource_name` and instead now having a `declared_type`.

This fixes #44 